### PR TITLE
Refresh BLE client before cover commands

### DIFF
--- a/custom_components/run_chicken/cover.py
+++ b/custom_components/run_chicken/cover.py
@@ -104,6 +104,8 @@ class RunChickenCoverEntity(CoordinatorEntity[DataUpdateCoordinator[RunChickenDe
         Ensures a connected `RunChickenCover` controller exists, then sends
         the open command to the device.
         """
+        await self.run_chicken_device.ensure_client_connected()
+        self.controller.client = self.run_chicken_device.client
         await self.controller.open_cover()
 
     async def async_close_cover(self, **kwargs: Any) -> None:  # noqa: ARG002
@@ -113,6 +115,8 @@ class RunChickenCoverEntity(CoordinatorEntity[DataUpdateCoordinator[RunChickenDe
         Ensures a connected `RunChickenCover` controller exists, then sends
         the close command to the device.
         """
+        await self.run_chicken_device.ensure_client_connected()
+        self.controller.client = self.run_chicken_device.client
         await self.controller.close_cover()
 
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
Issue(s): Closes #3

## Context
After a Run-Chicken door disconnects, `RunChickenDevice` can establish a replacement `BleakClient`, but the cover entity continues using the client captured during entity initialization. Commands sent through that stale client have no current GATT service cache and fail with `BleakCharacteristicNotFoundError` for the write characteristic.

## Changes in this PR
Before each open or close command, the cover entity ensures the device has an active connection and updates its controller to use the device's current client. This keeps command writes aligned with the client managed by `RunChickenDevice` after reconnects.

### Highlights
- `custom_components/run_chicken/cover.py`: Refresh the BLE connection and controller client before open and close writes.

## Validation outcomes
- Passed: Python bytecode compilation for the changed module.
- Passed: `git diff --check`.
- Passed: Applied the same patch to a Home Assistant 2026.4.2 installation using an ESPHome Bluetooth proxy; the integration loaded successfully after restart.
- Not run locally: Ruff is not installed in the local environment; repository CI will run lint and formatting checks.
- Not discovered: The repository does not contain an automated test suite for cover command behavior.
